### PR TITLE
10 fix unrecognized property exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the following dependency to the dependencies section of your project's `pom.
     <dependency>
         <groupId>io.github.sornerol</groupId>
         <artifactId>chesscom-pubapi-wrapper</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.0</version>
     </dependency>
 </dependencies
 ```
@@ -27,7 +27,7 @@ Add the following dependency to the dependencies section of your project's `buil
 ```
 dependencies {
     // other project dependencies...
-    compile 'io.github.sornerol:chesscom-pubapi-wrapper:1.0.0'
+    compile 'io.github.sornerol:chesscom-pubapi-wrapper:1.2.0'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.sornerol</groupId>
     <artifactId>chesscom-pubapi-wrapper</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -34,7 +34,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.14.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/io/github/sornerol/chess/pubapi/client/PubApiClientBase.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/client/PubApiClientBase.java
@@ -1,5 +1,6 @@
 package io.github.sornerol.chess.pubapi.client;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.sornerol.chess.pubapi.client.enums.ResponseCode;
 import io.github.sornerol.chess.pubapi.client.enums.RetryStrategy;
@@ -100,6 +101,7 @@ abstract class PubApiClientBase {
         String responseJson = getRequest(endpoint);
 
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return objectMapper.readValue(responseJson, clazz);
     }
 


### PR DESCRIPTION
Closes #10 
This fixes the UnrecognizedPropertyException that can happen when the response payload contains fields not recognized by the API wrapper. New properties will still need to be added in order to be used, but this will allow the wrapper to continue to work with existing known properties.