### PR TITLE
Migrate to httpclient5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.3.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/io/github/sornerol/chess/pubapi/client/PubApiClientBase.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/client/PubApiClientBase.java
@@ -8,11 +8,11 @@ import io.github.sornerol.chess.pubapi.exception.ChessComPubApiException;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHeader;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.message.BasicHeader;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -135,7 +135,7 @@ abstract class PubApiClientBase {
         boolean keepTrying = false;
         do {
             try (CloseableHttpResponse response = httpClient.execute(request)) {
-                int statusCode = response.getStatusLine().getStatusCode();
+                int statusCode = response.getCode();
                 if (statusCode == ResponseCode.RATE_LIMIT_EXCEEDED.getValue() && shouldTryRequestAgain(attempts)) {
                     keepTrying = true;
                     attempts++;


### PR DESCRIPTION
This change updates the API wrapper to use httpclient5.

Further work will need to be done to refactor `io.github.sornerol.chess.pubapi.client.PubApiClientBase#getRequest(java.lang.String)` so that it is not using the now deprecated `org.apache.hc.client5.http.impl.classic.CloseableHttpClient#execute(org.apache.hc.core5.http.ClassicHttpRequest)` method.