### PR TITLE
#28 user agent header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
             <version>2.15.1</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.11</version>
+        </dependency>
+        <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
             <scope>test</scope>
@@ -82,6 +87,12 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/sornerol/chess/pubapi/client/PubApiClientBase.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/client/PubApiClientBase.java
@@ -7,6 +7,7 @@ import io.github.sornerol.chess.pubapi.client.enums.RetryStrategy;
 import io.github.sornerol.chess.pubapi.exception.ChessComPubApiException;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * The base class of all the PubAPI client classes.
  */
+@Slf4j
 abstract class PubApiClientBase {
 
     /**
@@ -127,6 +129,10 @@ abstract class PubApiClientBase {
         HttpGet request = new HttpGet(endpoint);
         if (userAgent != null) {
             request.addHeader(new BasicHeader("User-Agent", userAgent));
+        } else {
+            log.warn("No User-Agent provided. Your request may not work. See " +
+                    "https://www.chess.com/announcements/view/breaking-change-user-agent-contact-info-required for" +
+                    "additional details");
         }
 
         String responseBody;


### PR DESCRIPTION
Closes #28 

This change warns the user if no User-Agent string is provided. Chess.com now requires all PubAPI requests to have valid contact information in the User-Agent header. From my local testing, it seems that they are not currently rejecting requests, so for now we will still attempt the request, but we will also log a warning with a link to the relevant information on Chess.com's website so as to encourage developers to start setting this field.