### PR TITLE
Add location field to Club domain object

### DIFF
--- a/src/main/java/io/github/sornerol/chess/pubapi/domain/club/Club.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/domain/club/Club.java
@@ -46,6 +46,14 @@ public class Club {
     private String countryApiUrl;
 
     /**
+     * The club's location. Note that this field appears to accept free-form
+     * text, so the returned value may not actually represent any sort
+     * of location.
+     */
+    @JsonProperty("location")
+    private String location;
+
+    /**
      * The average daily rating of club members
      */
     @JsonProperty("average_daily_rating")


### PR DESCRIPTION
This change adds the 'location' field to the Club domain object. This field appears to be a free-form text field, so the values returned in it may not actually represent the club's location.