### PR TITLE
Add StreamingPlatform domain object

### DIFF
--- a/src/main/java/io/github/sornerol/chess/pubapi/domain/player/Player.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/domain/player/Player.java
@@ -3,9 +3,12 @@ package io.github.sornerol.chess.pubapi.domain.player;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.sornerol.chess.pubapi.domain.player.enums.MembershipStatus;
 import io.github.sornerol.chess.pubapi.domain.player.enums.Title;
+import io.github.sornerol.chess.pubapi.domain.streamers.StreamingPlatform;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.util.List;
 
 /**
  * Details about a player
@@ -121,4 +124,14 @@ public class Player {
      */
     @JsonProperty("league")
     private String league;
+
+
+    /**
+     * If the player is a streamer, a list of streaming platforms associated with this player. Note that
+     * only the platformType and channelUrl fields are set when retrieving details using the player API
+     * endpoints. The Streamers API endpoint provides more details about streamers' streaming platforms.
+     */
+    @JsonProperty("streaming_platforms")
+    private List<StreamingPlatform> streamingPlatforms;
+
 }

--- a/src/main/java/io/github/sornerol/chess/pubapi/domain/streamers/Streamer.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/domain/streamers/Streamer.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.List;
+
 /**
  * Contains information about a Chess.com streamer.
  */
@@ -48,4 +50,10 @@ public class Streamer {
      */
     @JsonProperty("is_community_streamer")
     private Boolean isCommunityStreamer;
+
+    /**
+     * List of streaming platforms associated with this streamer
+     */
+    @JsonProperty("platforms")
+    private List<StreamingPlatform> streamingPlatforms;
 }

--- a/src/main/java/io/github/sornerol/chess/pubapi/domain/streamers/StreamingPlatform.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/domain/streamers/StreamingPlatform.java
@@ -1,0 +1,45 @@
+package io.github.sornerol.chess.pubapi.domain.streamers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Contains details about a streaming platform a {@link io.github.sornerol.chess.pubapi.domain.player.Player}
+ * or {@link Streamer} belongs to.
+ */
+@ToString
+@Getter
+@Setter
+public class StreamingPlatform {
+    /**
+     * The streaming platform name, such as Twitch or YouTube.
+     */
+    @JsonProperty("type")
+    private String platformType;
+
+    /**
+     * If the streamer is currently live, this field is set to the URL for the streamer's live stream.
+     */
+    @JsonProperty("stream_url")
+    private String streamUrl;
+
+    /**
+     * URL to the streamer's channel page on the streaming platform.
+     */
+    @JsonProperty("channel_url")
+    private String channelUrl;
+
+    /**
+     * Is the streamer live on this streaming platform?
+     */
+    @JsonProperty("is_live")
+    private Boolean isLive;
+
+    /**
+     * Is this platform the streamer's main live platform?
+     */
+    @JsonProperty("is_main_live_platform")
+    private Boolean isMainLivePlatform;
+}


### PR DESCRIPTION
This change adds a new StreamingPlatform domain object. This object is used by the Streamers and Players API to report details about streaming platforms that streamers belong to.