### PR TITLE
Add 'invited' as valid tournament status.

### DIFF
--- a/src/main/java/io/github/sornerol/chess/pubapi/domain/player/enums/PlayerTournamentStatus.java
+++ b/src/main/java/io/github/sornerol/chess/pubapi/domain/player/enums/PlayerTournamentStatus.java
@@ -35,7 +35,12 @@ public enum PlayerTournamentStatus {
     /**
      * Player was removed from the tournament by the tournament director
      */
-    REMOVED("removed");
+    REMOVED("removed"),
+
+    /**
+     * Player has received an invitation to join the tournament
+     */
+    INVITED("invited");
 
     @Getter
     @JsonValue


### PR DESCRIPTION
Adds "invited" as a valid tournament status. This status is used when a player has a pending invitation to a tournament.